### PR TITLE
Add in-memory log publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ clap = { version = "4.1.4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 bytes = { version = "1", features = ["serde"] }
 atoi = "0.3.2"
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # rog
+
 Distributed Commit Log
+
+## TODOs
+
+- Subscribe to log
+- Enable multiple subscribers to same log
+- Distribute writes to multiple nodes
+
+## Rog CLI
+
+TODO
+
+## Protocol specification
+
+TODO


### PR DESCRIPTION
Initial log publishing implementation using the tokio mpsc channel, the channels are sharded by the log partition so that there's one consumer per shard. This will be important because the log files will be split by partition and there can be only one writer to the partition.