### PR TITLE
Log fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Distributed Commit Log
 
 ## TODOs
 
-- Write messages to log file
-- Subscribe to log
 - Integration tests
 - Enable multiple subscribers to same log
 - Distribute writes to multiple nodes

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -30,6 +30,15 @@ enum Command {
         #[clap(long, short)]
         data: String,
     },
+    Fetch {
+        /// Log name
+        #[clap(long, short)]
+        log_name: String,
+
+        /// Partition to publish the data
+        #[clap(long, short)]
+        partition: usize,
+    },
 }
 
 #[derive(Debug, Parser)]
@@ -99,6 +108,26 @@ fn main() {
                     }
                 }
                 Err(e) => println!("Unable to publish to log\n{e}"),
+            }
+        }
+        Command::Fetch {
+            log_name,
+            partition,
+        } => {
+            let command = format!("2{partition}{CRLF}{log_name}{CRLF}");
+            let command = command.as_bytes();
+            if let Err(e) = stream.write_all(command) {
+                println!("Unable to fetch log\n{e}");
+                return;
+            }
+
+            let mut buf = [0; 1024];
+            match stream.read(&mut buf) {
+                Ok(_) => {
+                    let response = String::from_utf8_lossy(&buf);
+                    println!("{response}");
+                }
+                Err(e) => println!("Unable to fetch log\n{e}"),
             }
         }
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,22 +1,24 @@
-use std::{collections::HashMap, env, sync::Arc, time::SystemTime};
+use std::os::unix::ffi::OsStrExt;
+use std::{collections::HashMap, env, ffi::OsStr, path::Path, sync::Arc, time::SystemTime};
 
 use bytes::BytesMut;
 use serde::{Deserialize, Serialize};
 use tokio::{
     fs::{self, File, OpenOptions},
-    io::{self, AsyncWriteExt},
+    io::{self, AsyncReadExt, AsyncWriteExt},
     sync::{
         mpsc::{self, error::SendError, Receiver, Sender},
-        RwLock,
+        Mutex, RwLock,
     },
 };
-use tracing::{debug, error};
+use tracing::{debug, error, trace};
 
 #[derive(Debug)]
 pub struct CommitLog {
     pub name: String,
     pub partitions: usize,
     senders: Vec<Sender<InternalMessage>>,
+    rog_home: String,
 }
 
 impl CommitLog {
@@ -32,23 +34,25 @@ impl CommitLog {
             senders.push(tx);
             receivers.push(rx);
         }
+
+        let rog_home = match env::var("ROG_HOME") {
+            Ok(path) => path,
+            Err(_) => panic!("ROG_HOME environment variable not set"),
+        };
+
         (
             CommitLog {
                 name,
                 partitions: number_of_partitions,
                 senders,
+                rog_home,
             },
             receivers,
         )
     }
 
     pub async fn create_log_files(&self) -> Result<(), &str> {
-        let rog_home = match env::var("ROG_HOME") {
-            Ok(path) => path,
-            Err(_) => return Err("ROG_HOME environment variable not set"),
-        };
-
-        match fs::create_dir_all(format!("{rog_home}/{}", self.name)).await {
+        match fs::create_dir_all(format!("{}/{}", self.rog_home, self.name)).await {
             Ok(_) => debug!("Successfully created rog and log directories"),
             Err(e) => {
                 error!("Unable to create rog and log directory {e}");
@@ -57,10 +61,23 @@ impl CommitLog {
         }
 
         for partition in 0..self.partitions {
-            match File::create(format!("{rog_home}/{}/{partition}.log", self.name)).await {
-                Ok(_) => debug!("Successfully created log file for partition {partition}"),
+            match File::create(format!("{}/{}/{partition}.log", self.rog_home, self.name)).await {
+                Ok(_) => debug!(partition = partition, "Successfully created log file"),
                 Err(e) => {
-                    error!("Unable to create log file for partition {partition} {e}");
+                    error!(partition = partition, "Unable to create log file {e}");
+                    return Err("Unable to create log file for partition {partition}");
+                }
+            }
+            match File::create(format!("{}/{}/{partition}.id", self.rog_home, self.name)).await {
+                Ok(_) => debug!(
+                    partition = partition,
+                    "Successfully created partition id file"
+                ),
+                Err(e) => {
+                    error!(
+                        partition = partition,
+                        "Unable to create partition id file {e}"
+                    );
                     return Err("Unable to create log file for partition {partition}");
                 }
             }
@@ -77,52 +94,236 @@ impl CommitLog {
     }
 
     /// Initialize a list a receivers to run in background tasks.
-    pub fn setup_receivers(receivers: Vec<Receiver<InternalMessage>>) {
-        for mut receiver in receivers {
+    pub fn setup_receivers(receivers: Vec<Receiver<InternalMessage>>, log_name: String) {
+        let mut ids = Vec::new();
+        for _ in 0..receivers.len() {
+            ids.push(Mutex::new(0_usize));
+        }
+
+        let ids = Arc::new(ids);
+        for receiver in receivers {
+            let log_name = log_name.clone();
+            let ids = ids.clone();
             tokio::spawn(async move {
-                // TODO Micro-batching
-                while let Some(internal_message) = receiver.recv().await {
-                    let partition = internal_message.partition;
-                    let log_name = internal_message.log_name.clone();
-                    let message = Message::new(internal_message);
-
-                    let encoded = bincode::serialize(&message).unwrap();
-                    let rog_home = match env::var("ROG_HOME") {
-                        Ok(path) => path,
-                        Err(_) => panic!("ROG_HOME enrivonment variable not set"),
-                    };
-
-                    let log_file_name = format!("{rog_home}/{}/{}.log", log_name, partition);
-                    let result = OpenOptions::new().append(true).open(log_file_name).await;
-                    let mut log_file = match result {
-                        Ok(file) => file,
-                        Err(e) => {
-                            panic!("Unable to open log file for writing {e}");
-                        }
-                    };
-                    log_file.write_all(&encoded).await.unwrap();
-                    debug!(
-                        "Received message {:?} on partition {:?} with timestamp {:?}",
-                        message.data, partition, message.timestamp
-                    );
-                }
+                let ids = ids.clone();
+                let log_receiver = CommitLogReceiver::new(log_name);
+                log_receiver.handle_receiver(ids, receiver).await;
             });
         }
+    }
+
+    pub async fn fetch_message(&self, partition: usize) -> Result<BytesMut, &str> {
+        self.create_offset_files().await?;
+
+        let mut offset: usize = self.load_offset(partition).await;
+
+        // TODO Instead of loading the whole log in memory this
+        // function should only read part of the file, maybe for that
+        // I'll need to write a custom serializer instead of using
+        // Serde, or split the log in multiple smaller files, kind of
+        // how Postgres splits the data in pages of 8kb.
+        let log_file_name = format!("{}/{}/{}.log", self.rog_home, self.name, partition);
+        let mut log_file = File::open(log_file_name).await.unwrap();
+        let mut buf = Vec::new();
+        let _ = log_file.read_to_end(&mut buf).await.unwrap();
+
+        let log: HashMap<usize, Message> = if buf.is_empty() {
+            HashMap::new()
+        } else {
+            bincode::deserialize(&buf).unwrap()
+        };
+        let message = match log.get(&offset) {
+            Some(message) => message,
+            None => return Err("No data left in the log to be read"),
+        };
+
+        // TODO Offset file should only be updated if the response was
+        // sent successfully to the client, we have to make sure the
+        // client receives the message to update the offset.
+        self.increment_and_save_offset(partition, &mut offset).await;
+        Ok(message.data.clone())
+    }
+
+    async fn create_offset_files(&self) -> Result<(), &str> {
+        for partition in 0..self.partitions {
+            let offset_path = format!("{}/{}/{partition}.offset", self.rog_home, self.name);
+            if Path::new(&offset_path).exists() {
+                debug!(partition = partition, "Offset file already exists");
+                break;
+            }
+
+            match File::create(&offset_path).await {
+                Ok(_) => debug!(
+                    partition = partition,
+                    "Successfully created partition offset file"
+                ),
+                Err(e) => {
+                    error!(
+                        partition = partition,
+                        "Unable to create partition offset file {e}"
+                    );
+                    return Err("Unable to create log file for partition {partition}");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn load_offset(&self, partition: usize) -> usize {
+        let offset_file_name = format!("{}/{}/{}.offset", self.rog_home, self.name, partition);
+        let mut offset_file = File::open(&offset_file_name).await.unwrap();
+        let mut buf = Vec::new();
+        offset_file.read_to_end(&mut buf).await.unwrap();
+        if buf.is_empty() {
+            0
+        } else {
+            match bincode::deserialize(&buf) {
+                Ok(offset) => offset,
+                Err(_) => {
+                    debug!(
+                        partition = partition,
+                        "Offset not found on file, first message consumed on this partition"
+                    );
+                    0
+                }
+            }
+        }
+    }
+
+    async fn increment_and_save_offset(&self, partition: usize, offset: &mut usize) {
+        let offset_file_name = format!("{}/{}/{}.offset", self.rog_home, self.name, partition);
+        *offset += 1;
+        let binary_offset = bincode::serialize(&offset).unwrap();
+        let mut offset_file = OpenOptions::new()
+            .write(true)
+            .open(&offset_file_name)
+            .await
+            .unwrap();
+        offset_file.write_all(&binary_offset).await.unwrap();
+    }
+}
+
+pub struct CommitLogReceiver {
+    name: String,
+    rog_home: String,
+}
+
+impl CommitLogReceiver {
+    pub fn new(name: String) -> CommitLogReceiver {
+        let rog_home = match env::var("ROG_HOME") {
+            Ok(path) => path,
+            Err(_) => panic!("ROG_HOME environment variable not set"),
+        };
+
+        CommitLogReceiver { name, rog_home }
+    }
+
+    async fn handle_receiver(
+        &self,
+        ids: Arc<Vec<Mutex<usize>>>,
+        mut receiver: Receiver<InternalMessage>,
+    ) {
+        // TODO Micro-batching
+        while let Some(internal_message) = receiver.recv().await {
+            let partition = internal_message.partition;
+            let id = self.load_most_recent_id(&ids, partition).await;
+            let message = Message::new(id, internal_message);
+
+            let mut log = self.load_log_from_file(partition).await;
+            log.insert(message.id, message);
+
+            self.save_log_to_file(log, partition).await;
+
+            self.save_id_file(id, partition).await;
+        }
+    }
+
+    async fn load_most_recent_id(&self, ids: &Arc<Vec<Mutex<usize>>>, partition: usize) -> usize {
+        let mut id = ids[partition].lock().await;
+        // Checks if the current id has been loaded from
+        // the file or if it's the first message received.
+        if *id == 0 {
+            match self.load_id_from_file(partition).await {
+                Ok(saved_id) => {
+                    *id = saved_id + 1;
+                }
+                Err(_) => trace!(
+                    partition = partition,
+                    "Id not found on file, first message received on this partition"
+                ),
+            }
+        } else {
+            *id += 1;
+        }
+        *id
+    }
+
+    async fn load_id_from_file(&self, partition: usize) -> Result<usize, Box<bincode::ErrorKind>> {
+        let id_file_name = format!("{}/{}/{}.id", self.rog_home, self.name, partition);
+        let mut id_file = File::open(id_file_name).await.unwrap();
+        let mut buf = Vec::new();
+        let _ = id_file.read_to_end(&mut buf).await.unwrap();
+        bincode::deserialize(&buf)
+    }
+
+    async fn load_log_from_file(&self, partition: usize) -> HashMap<usize, Message> {
+        let log_file_name = format!("{}/{}/{}.log", self.rog_home, self.name, partition);
+        let result = File::open(&log_file_name).await;
+        let mut log_file = match result {
+            Ok(file) => file,
+            Err(e) => {
+                panic!("Unable to open log file {e}");
+            }
+        };
+        let mut buf = Vec::new();
+        log_file.read_to_end(&mut buf).await.unwrap();
+
+        let log: HashMap<usize, Message> = if buf.is_empty() {
+            HashMap::new()
+        } else {
+            bincode::deserialize(&buf).unwrap()
+        };
+        log
+    }
+
+    async fn save_log_to_file(&self, log: HashMap<usize, Message>, partition: usize) {
+        let encoded_log = bincode::serialize(&log).unwrap();
+        let log_file_name = format!("{}/{}/{}.log", self.rog_home, self.name, partition);
+        let result = OpenOptions::new().write(true).open(&log_file_name).await;
+        let mut log_file = match result {
+            Ok(file) => file,
+            Err(e) => {
+                panic!("Unable to open log file {e}");
+            }
+        };
+        log_file.write_all(&encoded_log).await.unwrap();
+    }
+
+    async fn save_id_file(&self, id: usize, partition: usize) {
+        let encoded_id = bincode::serialize(&id).unwrap();
+        let id_file_name = format!("{}/{}/{}.id", self.rog_home, self.name, partition);
+        let result = OpenOptions::new().write(true).open(id_file_name).await;
+
+        let mut id_file = match result {
+            Ok(file) => file,
+            Err(e) => {
+                panic!("Unable to open id file for writing {e}");
+            }
+        };
+        id_file.write_all(&encoded_id).await.unwrap();
     }
 }
 
 #[derive(Debug)]
 pub struct InternalMessage {
-    log_name: String,
     partition: usize,
     data: BytesMut,
     timestamp: SystemTime,
 }
 
 impl InternalMessage {
-    pub fn new(log_name: String, partition: usize, data: BytesMut) -> InternalMessage {
+    pub fn new(partition: usize, data: BytesMut) -> InternalMessage {
         InternalMessage {
-            log_name,
             partition,
             data,
             timestamp: SystemTime::now(),
@@ -132,13 +333,15 @@ impl InternalMessage {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Message {
+    id: usize,
     data: BytesMut,
     timestamp: SystemTime,
 }
 
 impl Message {
-    pub fn new(internal_message: InternalMessage) -> Message {
+    pub fn new(id: usize, internal_message: InternalMessage) -> Message {
         Message {
+            id,
             data: internal_message.data,
             timestamp: internal_message.timestamp,
         }
@@ -163,25 +366,34 @@ pub async fn load_logs(logs: Logs) {
 
     while let Some(entry) = dir.next_entry().await.unwrap() {
         let file_name = entry.file_name();
-        let log_name = file_name.to_string_lossy();
+        let log_name = file_name.to_string_lossy().to_string();
         let partitions = std::fs::read_dir(format!("{rog_home}/{log_name}"))
             .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().extension() == Some(OsStr::from_bytes(b"log")))
             .count();
-        let (commit_log, receivers) = CommitLog::new(log_name.to_string(), partitions);
-        CommitLog::setup_receivers(receivers);
-        logs.write().await.insert(log_name.to_string(), commit_log);
+        debug!(
+            partitions = partitions,
+            log_name = log_name,
+            "Loading log to memory",
+        );
+        let (commit_log, receivers) = CommitLog::new(log_name.clone(), partitions);
+        CommitLog::setup_receivers(receivers, commit_log.name.clone());
+        logs.write().await.insert(log_name, commit_log);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::log::*;
+    use std::env::set_var;
 
     #[test]
     fn create_new_commit_log() {
         let log_name = "log.name".to_string();
         let partitions = 10;
 
+        set_var("ROG_HOME", "~/.rog");
         let (commit_log, receivers) = CommitLog::new(log_name.clone(), partitions);
 
         assert_eq!(receivers.len(), partitions);
@@ -195,14 +407,14 @@ mod tests {
         let log_name = "log.name".to_string();
         let partitions = 10;
 
+        set_var("ROG_HOME", "~/.rog");
         let (commit_log, mut receivers) = CommitLog::new(log_name.clone(), partitions);
-        let message = InternalMessage::new(log_name.clone(), 0, BytesMut::new());
+        let message = InternalMessage::new(0, BytesMut::new());
         let result = commit_log.send_message(message).await;
 
         assert!(result.is_ok());
 
         let message = receivers[0].recv().await.unwrap();
-        assert_eq!(message.log_name, log_name);
         assert_eq!(message.partition, 0);
         assert_eq!(message.data, BytesMut::new());
         assert!(message.timestamp < SystemTime::now());


### PR DESCRIPTION
Adds the command to fetch a message from the log, the current implementation is highly inefficient because it loads the whole log in memory to publish and fetch a recent message.

I believe there are two possibilities to solve this issue:
1. Instead of loading the whole file in memory, just read part of the file, so that only the latest changed are loaded. The problem with this solution is serde, I think I'll need to write a custom serializer to implement it this way.
2. Split the messages in multiple files, kind of how PostgreSQL split the data into 8kb pages. This way only part of the log will be loaded in memory and the same serializer can be used.