### PR TITLE
Allow multiple consumers to same log

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Distributed Commit Log
 ## TODOs
 
 - Integration tests
-- Enable multiple subscribers to same log
 - Distribute writes to multiple nodes
 
 ## Rog CLI

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -38,6 +38,10 @@ enum Command {
         /// Partition to publish the data
         #[clap(long, short)]
         partition: usize,
+
+        /// Consumer group
+        #[clap(long, short)]
+        group: String,
     },
 }
 
@@ -113,8 +117,9 @@ fn main() {
         Command::Fetch {
             log_name,
             partition,
+            group,
         } => {
-            let command = format!("2{partition}{CRLF}{log_name}{CRLF}");
+            let command = format!("2{partition}{CRLF}{log_name}{CRLF}{group}{CRLF}");
             let command = command.as_bytes();
             if let Err(e) = stream.write_all(command) {
                 println!("Unable to fetch log\n{e}");


### PR DESCRIPTION
Add a consumer group parameter to the fetch command so that the offset is kept for each group, this way multiple consumers can read data from the log.