### PR TITLE
Add test profile to docker tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN python3 -m pip install protobuf
 
 RUN protoc -I=tests/proto --python_out=tests tests/proto/addressbook.proto
 
-RUN python3 tests/test_runner.py
+RUN python3 tests/test_runner.py docker

--- a/tests/rog_client.py
+++ b/tests/rog_client.py
@@ -10,8 +10,12 @@ import psutil
 CRLF = "\r\n"
 
 
-def initialize_rog_server(port: int = 7878, args: Optional[str] = None):
-    command = ["rog-server", "-p", str(port)]
+def initialize_rog_server(profile: str, port: int = 7878, args: Optional[str] = None):
+    if profile == "docker":
+        binary = "rog-server"
+    else:
+        binary = "./target/release/rog-server"
+    command = [binary, "-p", str(port)]
     if args is not None:
         command.extend(args.split(" "))
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,5 @@
 import glob
+import sys
 import os
 import subprocess
 import shutil
@@ -8,6 +9,11 @@ from rog_client import initialize_rog_server, kill_rog_server
 test_files = glob.glob("tests/*_test.py")
 
 os.environ["ROG_HOME"] = "/tmp/rog"
+
+try:
+    profile = sys.argv[1]
+except:
+    profile = "local"
 
 any_failed = False
 for test in test_files:
@@ -19,7 +25,7 @@ for test in test_files:
         pass
 
     os.mkdir("/tmp/rog")
-    pid = initialize_rog_server()
+    pid = initialize_rog_server(profile)
     try:
         print(f"Executing {test}")
         command = ["python", test]


### PR DESCRIPTION
To make it easier to run the integration tests add a flag for the test runner to run with the installed binary or the binary on the target directory.