### PR TITLE
Split log in multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ A simple distributed commit log inspired by [Kafka][0].
 
 ## Building
 
-To build both the cli and the server you can just run `cargo build --release`.
+To build both the cli and the server you can just run `cargo build
+--release`.
 
 ## Integration tests
 
 The integration tests are written in python. You can install the
 dependencies with pip: `pip install -r tests/requirements.txt`. The
-tests use protobuf for a few scenarios, so you need the protobuf compiler, you can generated the necessary files running this command:
+tests use protobuf for a few scenarios, so you need the protobuf
+compiler, you can generated the necessary files running this command:
 
 ```shell
 protoc -I=tests/proto --python_out=tests tests/proto/addressbook.proto
@@ -25,7 +27,7 @@ local docker image, this image is used simply to run this tests in an
 isolated environment.
 
 ```shell
-docker build -t rog:rog .
+docker buildx build .
 ```
 
 ## Rog CLI

--- a/tests/publish_big_message_test.py
+++ b/tests/publish_big_message_test.py
@@ -8,18 +8,33 @@ with open("tests/big_packet.txt") as fp:
 
 log_name = "big-packets.log"
 
+def send_big_message():
+    client.connect()
+    response = client.send_message(log_name, 0, data)
+    expected_response = f"+OK{CRLF}"
+    assert response.decode("utf-8") == expected_response
+
 client.connect()
 response = client.create_log(log_name, 2)
 expected_response = f"+OK{CRLF}"
 assert response.decode("utf-8") == expected_response
 
-client.connect()
-response = client.send_message(log_name, 0, data)
-expected_response = f"+OK{CRLF}"
-assert response.decode("utf-8") == expected_response
+# Send one big message
+send_big_message()
 
 sleep(0.1)
 
 client.connect()
 response = client.fetch_log(log_name, 0, "test-group", 5126)
 assert response.decode("utf-8") == data
+
+# Send multiple big messages
+for i in range(10):
+    send_big_message()
+
+sleep(0.1)
+
+for i in range(10):
+    client.connect()
+    response = client.fetch_log(log_name, 0, "test-group", 5126)
+    assert response.decode("utf-8") == data


### PR DESCRIPTION
One of the problems with the past implementation was that all messages were stored in a single file, because there's only one writer that's not such a big problem, but it ends up being very hard parse the file the bigger it gets. With this implementation rog tries to keep the log files at around 8kB, messages are stored on the file by their id. This way in the next step the messages will be stored in a different format, a format that allows the readers to not load the entire file in memory.