### PR TITLE
Log file format reestructure

### DIFF
--- a/tests/publish_and_fetch_test.py
+++ b/tests/publish_and_fetch_test.py
@@ -64,3 +64,9 @@ fetch_and_verify("other-events.log", 0, "test-group-2", expected_response)
 
 expected_response = f"second message"
 fetch_and_verify("other-events.log", 0, "test-group-2", expected_response)
+
+# Fetch data from a log with no data left
+client.connect()
+response = client.fetch_log("other-events.log", 0, "test-group-2")
+expected_response = "No data left in the log to be read"
+assert response.decode("utf-8") == expected_response


### PR DESCRIPTION
Creates a new file format for the log files. This new format allows rog
to fetch messages without loading the whole file in memory, this way the
read are more efficient. The writes are also more efficient because the
old format was just a HashMap with the messages read serialized with
bincode, instead load loading the whole file in memory, serializing the
HashMap and all the messages in that file, the write process now only needs
to append the record in the file.