### PR TITLE
Protocol revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,46 @@ Options:
 
 ## Protocol specification
 
-TODO
+In all commands the first byte is the command byte, this is used to
+identify which command is being sent. There are two client
+implementations in this repository: one in rust, [for the
+cli](./src/bin/cli.rs) and one in python used in the [integration
+tests](./tests/rog_client.py).
+
+### Commands
+
+#### Create log
+
+| Field         | type   | Description                               |
+|---------------|--------|-------------------------------------------|
+| Command byte  | u8     | Fixed value for the create log command, 0 |
+| partitions    | u8     | Number of partitions for the log          |
+| Log name size | u8     | Size of the log name in bytes             |
+| Log name      | String | Log name                                  |
+
+#### Publish
+
+| Field         | type   | Description                            |
+|---------------|--------|----------------------------------------|
+| Command byte  | u8     | Fixed value for the publish command, 1 |
+| partition     | u8     | Partitions to publish the message      |
+| Log name size | u8     | Size of the log name in bytes          |
+| Log name      | String | Log name                               |
+| Data size     | u64    | Size of the message in bytes           |
+| Data          | bytes  | The actual content of the message      |
+
+#### Fetch
+
+| Field         | type   | Description                                 |
+|---------------|--------|---------------------------------------------|
+| Command byte  | u8     | Fixed value for the fetch command, 2        |
+| partition     | u8     | Partition to fetch the message              |
+| Log name size | u8     | Size of the log name in bytes               |
+| Log name      | String | Log name                                    |
+| Data size     | u64    | Size of the content of the message in bytes |
+| Data          | bytes  | The actual content of the message           |
+
+
+TODO: Document responses
 
 [0]: https://kafka.apache.org/

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -110,7 +110,7 @@ async fn handle_connection(mut stream: TcpStream, logs: Logs) {
     send_response(&mut stream, response).await;
 }
 
-async fn create_log(logs: Logs, name: String, partitions: usize) -> Vec<u8> {
+async fn create_log(logs: Logs, name: String, partitions: u8) -> Vec<u8> {
     if partitions == 0 {
         let response = format!("-Number of partitions must be at least 1{CRLF}");
         return response.as_bytes().to_vec();
@@ -137,12 +137,7 @@ async fn create_log(logs: Logs, name: String, partitions: usize) -> Vec<u8> {
     }
 }
 
-async fn publish_message(
-    logs: Logs,
-    log_name: String,
-    partition: usize,
-    data: BytesMut,
-) -> Vec<u8> {
+async fn publish_message(logs: Logs, log_name: String, partition: u8, data: BytesMut) -> Vec<u8> {
     match logs.read().await.get(&log_name) {
         Some(log) => {
             let message = InternalMessage::new(partition, data);
@@ -176,13 +171,13 @@ async fn publish_message(
             }
         }
         None => {
-            let response = format!("-No log registered with name {log_name}{CRLF}");
+            let response = format!("-No log registered with name '{log_name}'{CRLF}");
             response.as_bytes().to_vec()
         }
     }
 }
 
-async fn fetch_log(logs: Logs, log_name: String, partition: usize, group: String) -> Vec<u8> {
+async fn fetch_log(logs: Logs, log_name: String, partition: u8, group: String) -> Vec<u8> {
     match logs.read().await.get(&log_name) {
         Some(log) => {
             let data = match log.fetch_message(partition, group).await {
@@ -196,7 +191,7 @@ async fn fetch_log(logs: Logs, log_name: String, partition: usize, group: String
             data.to_vec()
         }
         None => {
-            let response = format!("-No log registered with name {log_name}{CRLF}");
+            let response = format!("-No log registered with name '{log_name}'{CRLF}");
             response.as_bytes().to_vec()
         }
     }

--- a/tests/rog_client.py
+++ b/tests/rog_client.py
@@ -45,24 +45,68 @@ class RogClient:
         self.__socket.connect((self.IP, port))
 
     def create_log(self, log_name: str, partitions: int):
-        request = f"0{partitions}{CRLF}{log_name}{CRLF}"
-        self.__socket.send(request.encode("utf-8"))
+        command_byte = (0).to_bytes(1, byteorder="big")
+        partitions_bytes = partitions.to_bytes(1, byteorder="big")
+        log_name_size = len(log_name).to_bytes(1, byteorder="big")
+        log_name_bytes = log_name.encode("utf-8")
+
+        request = bytearray()
+        request.extend(command_byte)
+        request.extend(partitions_bytes)
+        request.extend(log_name_size)
+        request.extend(log_name_bytes)
+        self.__socket.send(request)
         return self.__socket.recv(1024)
 
-    def send_message(self, log_name: str, partition: int, data):
-        request = f"1{partition}{CRLF}{log_name}{CRLF}{data}{CRLF}"
-        self.__socket.send(request.encode("utf-8"))
+    def send_message(self, log_name: str, partition: int, data: str):
+        command_byte = (1).to_bytes(1, byteorder="big")
+        partition_bytes = partition.to_bytes(1, byteorder="big")
+        log_name_size = len(log_name).to_bytes(1, byteorder="big")
+        log_name_bytes = log_name.encode("utf-8")
+        data_size = len(data).to_bytes(8, byteorder="big")
+        data_bytes = data.encode("utf-8")
+
+        request = bytearray()
+        request.extend(command_byte)
+        request.extend(partition_bytes)
+        request.extend(log_name_size)
+        request.extend(log_name_bytes)
+        request.extend(data_size)
+        request.extend(data_bytes)
+        self.__socket.send(request)
         return self.__socket.recv(1024)
 
     def send_binary_message(self, log_name: str, partition: int, data: bytes):
-        request = f"1{partition}{CRLF}{log_name}{CRLF}"
-        request_bytes = bytearray(request.encode("utf-8"))
-        request_bytes.extend(data)
-        request_bytes.extend(CRLF.encode("utf-8"))
-        self.__socket.send(request_bytes)
+        command_byte = (1).to_bytes(1, byteorder="big")
+        partition_bytes = partition.to_bytes(1, byteorder="big")
+        log_name_size = len(log_name).to_bytes(1, byteorder="big")
+        log_name_bytes = log_name.encode("utf-8")
+        data_size = len(data).to_bytes(8, byteorder="big")
+
+        request = bytearray()
+        request.extend(command_byte)
+        request.extend(partition_bytes)
+        request.extend(log_name_size)
+        request.extend(log_name_bytes)
+        request.extend(data_size)
+        request.extend(data)
+        self.__socket.send(request)
         return self.__socket.recv(1024)
 
     def fetch_log(self, log_name: str, partition: int, group: str, buffer_size: int = 1024):
-        request = f"2{partition}{CRLF}{log_name}{CRLF}{group}{CRLF}"
-        self.__socket.send(request.encode("utf-8"))
+        command_byte = (2).to_bytes(1, byteorder="big")
+        partition_bytes = partition.to_bytes(1, byteorder="big")
+        log_name_size = len(log_name).to_bytes(1, byteorder="big")
+        log_name_bytes = log_name.encode("utf-8")
+        group_size = len(group).to_bytes(1, byteorder="big")
+        group_bytes = group.encode("utf-8")
+
+        request = bytearray()
+        request.extend(command_byte)
+        request.extend(partition_bytes)
+        request.extend(log_name_size)
+        request.extend(log_name_bytes)
+        request.extend(group_size)
+        request.extend(group_bytes)
+        self.__socket.send(request)
         return self.__socket.recv(buffer_size)


### PR DESCRIPTION
Reestructure the protocol to be more "binary friendly", the old protocol was built with RESP in my mind, given that I built something similar on ssache(eaneto/ssache). But RESP works better when dealing with strings, and rog messages are sent as bytes, so that the clients can send files without the need to transform them into text. The new protocol is a little more restrict in some ways, but much easier to parse and build clients. I started documenting the protocol in the README, at least for the requests, the responses are still undocumented.