### PR TITLE
Response revision and standardization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,5 @@ tracing-subscriber = "0.3"
 clap = { version = "4.1.4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 bytes = { version = "1", features = ["serde"] }
-atoi = "0.3.2"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Options:
 
 ## Protocol specification
 
-In all commands the first byte is the command byte, this is used to
-identify which command is being sent. There are two client
-implementations in this repository: one in rust, [for the
-cli](./src/bin/cli.rs) and one in python used in the [integration
-tests](./tests/rog_client.py).
+The Rog protocol is implemented with TCP. In all commands the first
+byte is the command byte, this is used to identify which command is
+being sent. There are two client implementations in this repository:
+one in rust, [for the cli](./src/bin/cli.rs) and one in python used in
+the [integration tests](./tests/rog_client.py).
 
 ### Commands
 
@@ -67,6 +67,12 @@ tests](./tests/rog_client.py).
 | Log name size | u8     | Size of the log name in bytes             |
 | Log name      | String | Log name                                  |
 
+##### Successful response
+
+| Field        | type | Description                                        |
+|--------------|------|----------------------------------------------------|
+| Success byte | u8   | Indicates if the response was successful or not, 0 |
+
 #### Publish
 
 | Field         | type   | Description                            |
@@ -77,6 +83,12 @@ tests](./tests/rog_client.py).
 | Log name      | String | Log name                               |
 | Data size     | u64    | Size of the message in bytes           |
 | Data          | bytes  | The actual content of the message      |
+
+##### Successful response
+
+| Field        | type | Description                                        |
+|--------------|------|----------------------------------------------------|
+| Success byte | u8   | Indicates if the response was successful or not, 0 |
 
 #### Fetch
 
@@ -89,7 +101,22 @@ tests](./tests/rog_client.py).
 | Data size     | u64    | Size of the content of the message in bytes |
 | Data          | bytes  | The actual content of the message           |
 
+##### Successful response
 
-TODO: Document responses
+| Field        | type   | Description                                        |
+|--------------|--------|----------------------------------------------------|
+| Success byte | u8     | Indicates if the response was successful or not, 0 |
+| Message size | u64    | Size of the message content                        |
+| Message      | String | Actual message                                     |
+
+#### Error response
+
+All commands have the same possible error response.
+
+| Field        | type   | Description                                        |
+|--------------|--------|----------------------------------------------------|
+| Success byte | u8     | Indicates if the response was successful or not, 1 |
+| Message size | u64    | Size of the error message                          |
+| Message      | String | Detailed error message                             |
 
 [0]: https://kafka.apache.org/

--- a/src/log.rs
+++ b/src/log.rs
@@ -67,7 +67,7 @@ impl CommitLog {
                 Ok(_) => debug!(partition = partition, "Successfully created partition file"),
                 Err(e) => {
                     error!(partition = partition, "Unable to create partition file {e}");
-                    return Err("Unable to create partition file {partition}");
+                    return Err("Unable to create partition file");
                 }
             }
 
@@ -75,7 +75,7 @@ impl CommitLog {
                 Ok(_) => debug!(partition = partition, "Successfully created log file"),
                 Err(e) => {
                     error!(partition = partition, "Unable to create log file {e}");
-                    return Err("Unable to create log file for partition {partition}");
+                    return Err("Unable to create log file for partition");
                 }
             }
             match File::create(format!("{}/{}/{partition}/id", self.rog_home, self.name)).await {
@@ -88,7 +88,7 @@ impl CommitLog {
                         partition = partition,
                         "Unable to create partition id file {e}"
                     );
-                    return Err("Unable to create log file for partition {partition}");
+                    return Err("Unable to create log file for partition");
                 }
             }
         }

--- a/tests/create_log_test.py
+++ b/tests/create_log_test.py
@@ -1,20 +1,24 @@
-from rog_client import RogClient, CRLF
+from rog_client import RogClient
 
 client = RogClient()
 
 client.connect()
 response = client.create_log("events.log", 10)
-expected_response = f"+OK{CRLF}"
-assert response.decode("utf-8") == expected_response
+expected_response = (0).to_bytes(1, byteorder="big")
+assert response == expected_response
 
 # Trying to create a log with existent log name
 client.connect()
 response = client.create_log("events.log", 10)
-expected_response = f"-Log events.log already exists{CRLF}"
-assert response.decode("utf-8") == expected_response
+assert response[0] == 1
+message_size = int.from_bytes(response[1:9], "big")
+expected_message = f"Log events.log already exists"
+assert response[9:(10+message_size)].decode("utf-8") == expected_message
 
 # Trying to create a log with 0 partitions
 client.connect()
 response = client.create_log("other-events.log", 0)
-expected_response = f"-Number of partitions must be at least 1{CRLF}"
-assert response.decode("utf-8") == expected_response
+assert response[0] == 1
+message_size = int.from_bytes(response[1:9], "big")
+expected_message = f"Number of partitions must be at least 1"
+assert response[9:(10+message_size)].decode("utf-8") == expected_message

--- a/tests/publish_and_fetch_protobuf_test.py
+++ b/tests/publish_and_fetch_protobuf_test.py
@@ -1,7 +1,7 @@
 from time import sleep
 
 from addressbook_pb2 import Person
-from rog_client import RogClient, CRLF
+from rog_client import RogClient
 from random import randint
 
 
@@ -22,22 +22,27 @@ client = RogClient()
 # Send one protobuf message
 client.connect()
 response = client.create_log("proto-events.log", 10)
-expected_response = f"+OK{CRLF}"
-assert response.decode("utf-8") == expected_response
+expected_response = (0).to_bytes(1, byteorder="big")
+assert response == expected_response
 
 person = build_person_object()
 data = person.SerializeToString()
 client.connect()
 response = client.send_binary_message("proto-events.log", 0, data)
-expected_response = f"+OK{CRLF}"
-assert response.decode("utf-8") == expected_response
+expected_response = (0).to_bytes(1, byteorder="big")
+assert response == expected_response
 
 sleep(0.1)
 
 client.connect()
 response = client.fetch_log("proto-events.log", 0, "proto-group")
+
+success_byte = (0).to_bytes(1, byteorder="big")
+assert response[0:1] == success_byte
+message_size = int.from_bytes(response[1:9], "big")
+
 response_person = Person()
-response_person.ParseFromString(response)
+response_person.ParseFromString(response[9:(10+message_size)])
 assert response_person.id == person.id
 assert response_person.name == person.name
 assert response_person.email == person.email
@@ -51,16 +56,21 @@ for i in range(25):
     data = person.SerializeToString()
     client.connect()
     response = client.send_binary_message("proto-events.log", 2, data)
-    expected_response = f"+OK{CRLF}"
-    assert response.decode("utf-8") == expected_response
+    expected_response = (0).to_bytes(1, byteorder="big")
+    assert response == expected_response
 
 sleep(1)
 
 for person in persons:
     client.connect()
     response = client.fetch_log("proto-events.log", 2, "proto-group")
+
+    success_byte = (0).to_bytes(1, byteorder="big")
+    assert response[0:1] == success_byte
+    message_size = int.from_bytes(response[1:9], "big")
+
     response_person = Person()
-    response_person.ParseFromString(response)
+    response_person.ParseFromString(response[9:(10+message_size)])
     assert response_person.id == person.id
     assert response_person.name == person.name
     assert response_person.email == person.email

--- a/tests/publish_and_fetch_test.py
+++ b/tests/publish_and_fetch_test.py
@@ -1,26 +1,29 @@
 from time import sleep
 
-from rog_client import RogClient, CRLF
+from rog_client import RogClient
 
 client = RogClient()
 
 def send_and_verify(log_name: str, partition: int, message: str):
     client.connect()
     response = client.send_message(log_name, partition, message)
-    expected_response = f"+OK{CRLF}"
-    assert response.decode("utf-8") == expected_response
+    expected_response = (0).to_bytes(1, byteorder="big")
+    assert response == expected_response
 
 
 def fetch_and_verify(log_name: str, partition: int, group: str, expected_response: str):
     client.connect()
     response = client.fetch_log(log_name, partition, group)
-    assert response.decode("utf-8") == expected_response
+    success_byte = (0).to_bytes(1, byteorder="big")
+    assert response[0:1] == success_byte
+    message_size = int.from_bytes(response[1:9], "big")
+    assert response[9:(10+message_size)].decode("utf-8") == expected_response
 
 # Test publishing one message to each partition in a log
 client.connect()
 response = client.create_log("events.log", 10)
-expected_response = f"+OK{CRLF}"
-assert response.decode("utf-8") == expected_response
+expected_response = (0).to_bytes(1, byteorder="big")
+assert response == expected_response
 
 for i in range(10):
     send_and_verify("events.log", i, "some data")
@@ -45,8 +48,8 @@ fetch_and_verify("events.log", 0, "test-group", expected_response)
 # Test fetching data from same partition with different groups
 client.connect()
 response = client.create_log("other-events.log", 10)
-expected_response = f"+OK{CRLF}"
-assert response.decode("utf-8") == expected_response
+expected_response = (0).to_bytes(1, byteorder="big")
+assert response == expected_response
 
 send_and_verify("other-events.log", 0, "first message")
 send_and_verify("other-events.log", 0, "second message")
@@ -68,5 +71,7 @@ fetch_and_verify("other-events.log", 0, "test-group-2", expected_response)
 # Fetch data from a log with no data left
 client.connect()
 response = client.fetch_log("other-events.log", 0, "test-group-2")
-expected_response = "No data left in the log to be read"
-assert response.decode("utf-8") == expected_response
+assert response[0] == 1
+message_size = int.from_bytes(response[1:9], "big")
+expected_message = "No data left in the log to be read"
+assert response[9:(10+message_size)].decode("utf-8") == expected_message

--- a/tests/rog_client.py
+++ b/tests/rog_client.py
@@ -7,8 +7,6 @@ from typing import Optional
 
 import psutil
 
-CRLF = "\r\n"
-
 
 def initialize_rog_server(profile: str, port: int = 7878, args: Optional[str] = None):
     if profile == "docker":


### PR DESCRIPTION
Rewrite all responses to follow the same structure. The first byte of any response indicates if there were any errors processing the request, if the byte is 0 there were no errors and if it is one there was some kind of error. In the case of the create log and publish commands the successful response only returns one byte, on the fetch command the first byte is 0, the following 8 bytes the message size and the following N bytes the actual messages fetched from the log.

All commands have the same error response structure, with the first byte being 1, the next 8 bytes the message size and the following N bytes the actual error message.