### PR TITLE
Adds new integration tests validating persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN python3 -m pip install protobuf pytest
 
 RUN protoc -I=tests/proto --python_out=tests tests/proto/addressbook.proto
 
-RUN pytest tests --profile=docker
+RUN pytest -s tests --profile=docker

--- a/tests/check_log_loading_after_restart_test.py
+++ b/tests/check_log_loading_after_restart_test.py
@@ -1,0 +1,41 @@
+import os
+import signal
+from time import sleep
+
+import psutil
+
+from rog_client import (
+    RogClient,
+    create_log_and_check_success,
+    fetch_message_and_check_success,
+    send_message_and_check_success,
+)
+from rog_setup import initialize_rog_server, kill_rog_server
+
+
+def find_and_kill_rog_server():
+    processes = psutil.process_iter()
+    name = "rog-server"
+    ssache_process = [p for p in processes if name in p.name()][0]
+    os.kill(ssache_process.pid, signal.SIGTERM)
+
+
+def test_log_loading_after_server_restart(request):
+    client = RogClient()
+    log_name = "restart.log"
+
+    create_log_and_check_success(client, log_name, 10)
+
+    message = "random message"
+    send_message_and_check_success(client, log_name, 0, message)
+
+    sleep(0.1)
+
+    find_and_kill_rog_server()
+
+    profile = request.config.getoption("--profile")
+    pid = initialize_rog_server(profile)
+
+    fetch_message_and_check_success(client, log_name, 0, "test-group", message)
+
+    kill_rog_server(pid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,11 @@ def setup_and_teardown_rog_server(request):
     if request.config.getoption("--setup-server") == "true":
         pid = setup_rog_server(request)
         yield
-        kill_rog_server(pid)
+        try:
+            kill_rog_server(pid)
+        except:
+            # Ignores if it's not possible to kill the server, that
+            # means the test has already killed it.
+            pass
     else:
         yield

--- a/tests/create_log_test.py
+++ b/tests/create_log_test.py
@@ -6,20 +6,19 @@ def test_log_creation_with_success():
     create_log_and_check_success(client, "events.log", 10)
 
 
-# Trying to create a log with existent log name
 def test_log_creation_with_existent_log_name():
     client = RogClient()
-    create_log_and_check_success(client, "events.log", 10)
+    log_name = "existent-log.log"
+    create_log_and_check_success(client, log_name, 10)
 
     client.connect()
-    response = client.create_log("events.log", 10)
+    response = client.create_log(log_name, 10)
     assert response[0] == 1
     message_size = int.from_bytes(response[1:9], "big")
-    expected_message = f"Log events.log already exists"
+    expected_message = f"Log {log_name} already exists"
     assert response[9 : (10 + message_size)].decode("utf-8") == expected_message
 
 
-# Trying to create a log with 0 partitions
 def test_log_creation_with_invalid_number_of_partitions():
     client = RogClient()
     client.connect()

--- a/tests/publish_and_fetch_protobuf_test.py
+++ b/tests/publish_and_fetch_protobuf_test.py
@@ -20,19 +20,20 @@ def build_person_object():
 def test_send_one_protobuf_message():
     client = RogClient()
 
-    create_log_and_check_success(client, "proto-events.log", 10)
+    log_name = "single-proto-event.log"
+    create_log_and_check_success(client, log_name, 10)
 
     person = build_person_object()
     data = person.SerializeToString()
     client.connect()
-    response = client.send_binary_message("proto-events.log", 0, data)
+    response = client.send_binary_message(log_name, 0, data)
     expected_response = (0).to_bytes(1, byteorder="big")
     assert response == expected_response
 
     sleep(0.1)
 
     client.connect()
-    response = client.fetch_log("proto-events.log", 0, "proto-group")
+    response = client.fetch_log(log_name, 0, "proto-group")
 
     success_byte = (0).to_bytes(1, byteorder="big")
     assert response[0:1] == success_byte
@@ -48,8 +49,9 @@ def test_send_one_protobuf_message():
 
 def test_send_multiple_protobuf_messages_to_same_partition():
     client = RogClient()
+    log_name = "multiple-proto-events.log"
 
-    create_log_and_check_success(client, "proto-events.log", 10)
+    create_log_and_check_success(client, log_name, 10)
 
     persons = []
     for i in range(25):
@@ -57,7 +59,7 @@ def test_send_multiple_protobuf_messages_to_same_partition():
         persons.append(person)
         data = person.SerializeToString()
         client.connect()
-        response = client.send_binary_message("proto-events.log", 2, data)
+        response = client.send_binary_message(log_name, 2, data)
         expected_response = (0).to_bytes(1, byteorder="big")
         assert response == expected_response
 
@@ -65,7 +67,7 @@ def test_send_multiple_protobuf_messages_to_same_partition():
 
     for person in persons:
         client.connect()
-        response = client.fetch_log("proto-events.log", 2, "proto-group")
+        response = client.fetch_log(log_name, 2, "proto-group")
 
         success_byte = (0).to_bytes(1, byteorder="big")
         assert response[0:1] == success_byte

--- a/tests/publish_and_fetch_test.py
+++ b/tests/publish_and_fetch_test.py
@@ -10,74 +10,81 @@ from rog_client import (
 
 def test_publish_one_message_to_each_partition():
     client = RogClient()
+    log_name = "single-message-to-partition.log"
 
-    create_log_and_check_success(client, "events.log", 10)
+    create_log_and_check_success(client, log_name, 10)
 
     for i in range(10):
-        send_message_and_check_success(client, "events.log", i, "some data")
+        send_message_and_check_success(client, log_name, i, "some data")
 
         sleep(0.1)
 
         expected_response = "some data"
         fetch_message_and_check_success(
-            client, "events.log", i, "test-group", expected_response
+            client, log_name, i, "test-group", expected_response
         )
 
 
 def test_publishing_more_than_one_message_to_same_partitions():
     client = RogClient()
-    create_log_and_check_success(client, "events.log", 10)
-    send_message_and_check_success(client, "events.log", 0, "first message")
-    send_message_and_check_success(client, "events.log", 0, "second message")
+    log_name = "multiple-messages-to-partition.log"
+
+    create_log_and_check_success(client, log_name, 10)
+    send_message_and_check_success(client, log_name, 0, "first message")
+    send_message_and_check_success(client, log_name, 0, "second message")
 
     sleep(0.1)
 
     expected_response = f"first message"
     fetch_message_and_check_success(
-        client, "events.log", 0, "test-group", expected_response
+        client, log_name, 0, "test-group", expected_response
     )
 
     expected_response = f"second message"
     fetch_message_and_check_success(
-        client, "events.log", 0, "test-group", expected_response
+        client, log_name, 0, "test-group", expected_response
     )
 
 
 def test_fetching_data_from_same_partition_with_differente_groups():
     client = RogClient()
-    create_log_and_check_success(client, "other-events.log", 10)
+    log_name = "multiple-groups.log"
 
-    send_message_and_check_success(client, "other-events.log", 0, "first message")
-    send_message_and_check_success(client, "other-events.log", 0, "second message")
+    create_log_and_check_success(client, log_name, 10)
+
+    send_message_and_check_success(client, log_name, 0, "first message")
+    send_message_and_check_success(client, log_name, 0, "second message")
 
     sleep(0.1)
 
     expected_response = f"first message"
     fetch_message_and_check_success(
-        client, "other-events.log", 0, "test-group-1", expected_response
+        client, log_name, 0, "test-group-1", expected_response
     )
 
     expected_response = f"second message"
     fetch_message_and_check_success(
-        client, "other-events.log", 0, "test-group-1", expected_response
+        client, log_name, 0, "test-group-1", expected_response
     )
 
     expected_response = f"first message"
     fetch_message_and_check_success(
-        client, "other-events.log", 0, "test-group-2", expected_response
+        client, log_name, 0, "test-group-2", expected_response
     )
 
     expected_response = f"second message"
     fetch_message_and_check_success(
-        client, "other-events.log", 0, "test-group-2", expected_response
+        client, log_name, 0, "test-group-2", expected_response
     )
 
 
 def test_fetch_data_from_a_log_with_no_data_left():
     client = RogClient()
-    create_log_and_check_success(client, "other-events.log", 10)
+    log_name = "no-data.log"
+
+    create_log_and_check_success(client, log_name, 10)
     client.connect()
-    response = client.fetch_log("other-events.log", 0, "test-group-2")
+    response = client.fetch_log(log_name, 0, "test-group-2")
     assert response[0] == 1
     message_size = int.from_bytes(response[1:9], "big")
     expected_message = "No data left in the log to be read"

--- a/tests/publish_big_message_test.py
+++ b/tests/publish_big_message_test.py
@@ -8,11 +8,10 @@ from rog_client import (
     send_binary_message_and_check_success,
 )
 
-log_name = "big-packets.log"
-
 
 def test_send_message_with_5kb():
     client = RogClient()
+    log_name = "single-big-message.log"
 
     create_log_and_check_success(client, log_name, 2)
 
@@ -27,9 +26,9 @@ def test_send_message_with_5kb():
     )
 
 
-# Send multiple big messages
 def test_send_multiple_messages_with_600kB():
     client = RogClient()
+    log_name = "multiple-big-messages.log"
 
     create_log_and_check_success(client, log_name, 2)
 


### PR DESCRIPTION
Adds a new test checking that even after a restart, the log and the
messages are still persisted and loaded in-memory. The logs created at
each test was renamed to something specific to the test.