### PR TITLE
Implements ack command and remove offset incrementation from fetch

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -135,7 +135,7 @@ impl CommitLog {
     ) -> Result<BytesMut, &str> {
         self.create_offset_files(&group).await?;
 
-        let mut offset: usize = self.load_offset(partition, &group).await;
+        let offset: usize = self.load_offset(partition, &group).await;
 
         let log_segment_filename = self
             .find_log_segment_for_offset(log_segments, offset, partition)
@@ -186,12 +186,13 @@ impl CommitLog {
             }
         };
 
-        // TODO Offset file should only be updated if the response was
-        // sent successfully to the client, we have to make sure the
-        // client receives the message to update the offset.
+        Ok(entry.data)
+    }
+
+    pub async fn ack_message(&self, partition: u8, group: String) {
+        let mut offset: usize = self.load_offset(partition, &group).await;
         self.increment_and_save_offset(partition, &group, &mut offset)
             .await;
-        Ok(entry.data.clone())
     }
 
     async fn create_offset_files(&self, group: &String) -> Result<(), &str> {

--- a/tests/check_log_loading_after_restart_test.py
+++ b/tests/check_log_loading_after_restart_test.py
@@ -6,6 +6,7 @@ import psutil
 
 from rog_client import (
     RogClient,
+    ack_message_and_check_success,
     create_log_and_check_success,
     fetch_message_and_check_success,
     send_message_and_check_success,
@@ -37,5 +38,7 @@ def test_log_loading_after_server_restart(request):
     pid = initialize_rog_server(profile)
 
     fetch_message_and_check_success(client, log_name, 0, "test-group", message)
+
+    ack_message_and_check_success(client, log_name, 0, "test-group")
 
     kill_rog_server(pid)

--- a/tests/publish_and_fetch_test.py
+++ b/tests/publish_and_fetch_test.py
@@ -2,6 +2,7 @@ from time import sleep
 
 from rog_client import (
     RogClient,
+    ack_message_and_check_success,
     create_log_and_check_success,
     fetch_message_and_check_success,
     send_message_and_check_success,
@@ -23,6 +24,7 @@ def test_publish_one_message_to_each_partition():
         fetch_message_and_check_success(
             client, log_name, i, "test-group", expected_response
         )
+        ack_message_and_check_success(client, log_name, i, "test-group")
 
 
 def test_publishing_more_than_one_message_to_same_partitions():
@@ -39,6 +41,8 @@ def test_publishing_more_than_one_message_to_same_partitions():
     fetch_message_and_check_success(
         client, log_name, 0, "test-group", expected_response
     )
+
+    ack_message_and_check_success(client, log_name, 0, "test-group")
 
     expected_response = f"second message"
     fetch_message_and_check_success(
@@ -62,20 +66,28 @@ def test_fetching_data_from_same_partition_with_differente_groups():
         client, log_name, 0, "test-group-1", expected_response
     )
 
+    ack_message_and_check_success(client, log_name, 0, "test-group-1")
+
     expected_response = f"second message"
     fetch_message_and_check_success(
         client, log_name, 0, "test-group-1", expected_response
     )
+
+    ack_message_and_check_success(client, log_name, 0, "test-group-1")
 
     expected_response = f"first message"
     fetch_message_and_check_success(
         client, log_name, 0, "test-group-2", expected_response
     )
 
+    ack_message_and_check_success(client, log_name, 0, "test-group-2")
+
     expected_response = f"second message"
     fetch_message_and_check_success(
         client, log_name, 0, "test-group-2", expected_response
     )
+
+    ack_message_and_check_success(client, log_name, 0, "test-group-2")
 
 
 def test_fetch_data_from_a_log_with_no_data_left():
@@ -89,3 +101,32 @@ def test_fetch_data_from_a_log_with_no_data_left():
     message_size = int.from_bytes(response[1:9], "big")
     expected_message = "No data left in the log to be read"
     assert response[9 : (10 + message_size)].decode("utf-8") == expected_message
+
+
+def test_publishing_more_than_one_message_to_same_partitions_without_acks():
+    client = RogClient()
+    log_name = "multiple-messages-to-partition-without-acks.log"
+
+    create_log_and_check_success(client, log_name, 10)
+    send_message_and_check_success(client, log_name, 0, "first message")
+    send_message_and_check_success(client, log_name, 0, "second message")
+
+    sleep(0.1)
+
+    expected_response = f"first message"
+    fetch_message_and_check_success(
+        client, log_name, 0, "test-group", expected_response
+    )
+    fetch_message_and_check_success(
+        client, log_name, 0, "test-group", expected_response
+    )
+    fetch_message_and_check_success(
+        client, log_name, 0, "test-group", expected_response
+    )
+
+    ack_message_and_check_success(client, log_name, 0, "test-group")
+
+    expected_response = f"second message"
+    fetch_message_and_check_success(
+        client, log_name, 0, "test-group", expected_response
+    )

--- a/tests/rog_client.py
+++ b/tests/rog_client.py
@@ -77,6 +77,26 @@ class RogClient:
         self.__socket.send(request)
         return self.__socket.recv(buffer_size)
 
+    def ack_message(
+        self, log_name: str, partition: int, group: str, buffer_size: int = 1024
+    ):
+        command_byte = (3).to_bytes(1, byteorder="big")
+        partition_bytes = partition.to_bytes(1, byteorder="big")
+        log_name_size = len(log_name).to_bytes(1, byteorder="big")
+        log_name_bytes = log_name.encode("utf-8")
+        group_size = len(group).to_bytes(1, byteorder="big")
+        group_bytes = group.encode("utf-8")
+
+        request = bytearray()
+        request.extend(command_byte)
+        request.extend(partition_bytes)
+        request.extend(log_name_size)
+        request.extend(log_name_bytes)
+        request.extend(group_size)
+        request.extend(group_bytes)
+        self.__socket.send(request)
+        return self.__socket.recv(buffer_size)
+
 
 def create_log_and_check_success(client: RogClient, log_name: str, partitions: int):
     client.connect()
@@ -133,3 +153,16 @@ def fetch_binary_message_and_check_success(
     assert response[0:1] == success_byte
     message_size = int.from_bytes(response[1:9], "big")
     assert response[9 : (10 + message_size)] == expected_message
+
+
+def ack_message_and_check_success(
+    client: RogClient,
+    log_name: str,
+    partition: int,
+    group: str,
+    buffer_size: int = 1024,
+):
+    client.connect()
+    response = client.ack_message(log_name, partition, group, buffer_size)
+    success_byte = (0).to_bytes(1, byteorder="big")
+    assert response[0:1] == success_byte


### PR DESCRIPTION
Separates the offset incrementation from the fetch command, this is done so that the if the client is processing the fetched and message and for some reason encounters an error it'll be possible to consume the same message again. This way the clients have to make a new request to only acknowledge the message, incrementing the log group offset.